### PR TITLE
Add layout attribute to amp-img

### DIFF
--- a/spec/Converter/ImageConverterSpec.php
+++ b/spec/Converter/ImageConverterSpec.php
@@ -28,6 +28,7 @@ class ImageConverterSpec extends ObjectBehavior
         $ampImg->setAttribute('srcset', '')->shouldNotBeCalled();
         $ampImg->setAttribute('alt', '')->shouldNotBeCalled();
         $ampImg->setAttribute('attribution', '')->shouldNotBeCalled();
+        $ampImg->setAttribute('layout', '')->shouldNotBeCalled();
 
         $element->getAttribute('src')->shouldBeCalled()->willReturn('foo.jpg');
         $element->getAttribute('width')->shouldBeCalled()->willReturn(300);
@@ -36,6 +37,7 @@ class ImageConverterSpec extends ObjectBehavior
         $element->getAttribute('srcset')->shouldBeCalled()->willReturn('');
         $element->getAttribute('alt')->shouldBeCalled()->willReturn('');
         $element->getAttribute('attribution')->shouldBeCalled()->willReturn('');
+        $element->getAttribute('layout')->shouldBeCalled()->willReturn('');
 
         $element
             ->createWritableElement('amp-img')

--- a/src/Converter/ImageConverter.php
+++ b/src/Converter/ImageConverter.php
@@ -8,7 +8,7 @@ use Predmond\HtmlToAmp\ElementInterface;
 class ImageConverter implements ConverterInterface
 {
     private $validAttributes = [
-        'src', 'width', 'height', 'srcset', 'alt', 'attribution', 'class'
+        'src', 'width', 'height', 'srcset', 'alt', 'attribution', 'class', 'layout'
     ];
 
     public function handleTagImg(EventInterface $event, ElementInterface $element)


### PR DESCRIPTION
AMP tags have [many attributes](https://www.ampproject.org/docs/reference/common_attributes) and one of them is `layout` for `amp-img` which allows you to control the layout of images, i.e `layout="responsive"` to obtain a responsive image. I only added 1, it could be easy to let user pre-define them or alter the private property `$validAttributes` of `Predmond\HtmlToAmp\Converter\ImageConverter` class.

Thanks!
Samuel